### PR TITLE
Add free-tier deploy config: Vercel + Supabase keepalive

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,35 @@
+name: Keepalive
+
+# Pings the deployed readiness probe so the Supabase free tier does not pause
+# after 7 idle days. /api/ready runs a real database query (unlike /api/health),
+# so it counts as activity. Set repository variable APP_URL to the deployed URL.
+on:
+  schedule:
+    # Every 2 days at 08:17 UTC — margin under the 7-day idle window.
+    - cron: "17 8 */2 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: keepalive
+  cancel-in-progress: false
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping readiness probe (touches database)
+        env:
+          APP_URL: ${{ vars.APP_URL }}
+        run: |
+          if [ -z "$APP_URL" ]; then
+            echo "APP_URL repository variable is not set; skipping." >&2
+            exit 0
+          fi
+          target="${APP_URL%/}/api/ready"
+          echo "Pinging $target"
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-delay 15 --retry-all-errors \
+            --max-time 60 "$target"

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build"
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,68 @@
+# Deployment
+
+## Artifact
+
+`apps/web/Dockerfile` builds a non-root Next.js standalone image with an HTTP liveness check. CI builds the same artifact. A managed Next.js host is also valid if it preserves stdout JSON and server-only secrets.
+
+## Required production configuration
+
+- Public: app URL, Supabase URL/publishable key
+- Server: Supabase service-role key, Stripe secret/webhook secret/price IDs
+- Operations: `LOG_LEVEL`, immutable `RELEASE_SHA`
+
+Never expose service-role or Stripe values to `NEXT_PUBLIC_*`.
+
+## Release order
+
+1. Confirm CI, dependency audits, backup/PITR, and staging smoke are green.
+2. Apply reviewed forward-compatible migrations. Never edit production schema through a dashboard.
+3. Deploy the immutable image with `RELEASE_SHA` set to the commit.
+4. Require `/api/health` for liveness and `/api/ready` for traffic readiness.
+5. Verify login, tenant isolation, a read-only API call, Stripe test event, logs, and alerts.
+6. Monitor error rate, p95 latency, billing webhook failures, and oldest pending outbox event.
+
+Rollback application code to the prior image. Do not reverse a migration unless a reviewed down migration is proven safe; prefer roll-forward fixes.
+
+## Environments
+
+Use separate Supabase and Stripe projects for preview/staging/production. Production branch protection requires CI, review, and migration approval. Rotate secrets after staff/vendor access changes.
+
+## Free-tier deployment (Vercel Hobby + Supabase Free)
+
+For demos, portfolios, and pre-revenue MVPs. Cost: $0.
+
+**Caveat:** Vercel Hobby is non-commercial only — processing real payments (live Stripe) violates its terms. Keep Stripe in test mode here, or move `apps/web` to a commercial-friendly host (Vercel Pro, or a Render free web service) pointed at the same Supabase project.
+
+### Stack
+
+- `apps/web` → Vercel Hobby. Vercel uses its native Next.js build; the `Dockerfile` and `output: "standalone"` are ignored (harmless).
+- `supabase/` → Supabase Free: 500 MB database, 1 GB storage, 2 projects, no backups. Pauses after 7 days with no database queries.
+- Stripe → test mode.
+
+### Steps
+
+1. **Supabase:** create a free project. `supabase link --project-ref <ref>`, then `supabase db push` to apply `supabase/migrations`. Copy the project URL and publishable key.
+2. **Vercel:** import the GitHub repo and set **Root Directory = `apps/web`**. `apps/web/vercel.json` pins the framework and commands.
+3. **Environment variables** (Vercel project settings, from `apps/web/.env.example`):
+
+   | Variable | Scope | Value |
+   | --- | --- | --- |
+   | `NEXT_PUBLIC_APP_URL` | Public | Deployed URL, e.g. `https://your-app.vercel.app` |
+   | `NEXT_PUBLIC_SUPABASE_URL` | Public | Supabase project URL |
+   | `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Public | Supabase publishable key |
+   | `SUPABASE_SERVICE_ROLE_KEY` | Server only | Service-role key — never `NEXT_PUBLIC_*` |
+   | `STRIPE_SECRET_KEY` | Server only | `sk_test_…` |
+   | `STRIPE_WEBHOOK_SECRET` | Server only | `whsec_…` from the webhook created in step 4 |
+   | `STRIPE_PRICE_STARTER` | Server only | `price_…` |
+   | `STRIPE_PRICE_PRO` | Server only | `price_…` |
+   | `LOG_LEVEL` | Server only | `info` |
+   | `RELEASE_SHA` | Server only | Deploy commit SHA (Vercel exposes `VERCEL_GIT_COMMIT_SHA`) |
+
+4. **Stripe:** add a webhook endpoint at `https://<app-url>/api/v1/webhooks/stripe`, subscribe to the checkout/subscription events the app handles, and copy its signing secret into `STRIPE_WEBHOOK_SECRET`.
+5. **Keep Supabase awake:** set repository variable `APP_URL` to the deployed URL. `.github/workflows/keepalive.yml` pings `/api/ready` (a real database query) every 2 days.
+
+### Notes
+
+- The keepalive workflow only runs on schedule from the **default branch** — merge it to `main`. GitHub disables scheduled workflows after 60 days of repository inactivity; a manual `workflow_dispatch` run re-arms it.
+- Supabase Free has no backups or PITR — it is not a production system of record.
+- Verify after first deploy: `GET /api/health` (liveness) and `GET /api/ready` (database-backed readiness).


### PR DESCRIPTION
Free-tier deployment support (Vercel Hobby + Supabase Free).

- `apps/web/vercel.json` — pin Next.js framework/commands for monorepo root dir
- `.github/workflows/keepalive.yml` — ping /api/ready every 2d to keep Supabase free tier awake
- `docs/deployment.md` — free-tier deployment section

🤖 Generated with [Claude Code](https://claude.com/claude-code)